### PR TITLE
Change pension statement from yearly income to monthly income type.  Fixes #36

### DIFF
--- a/clients/models.py
+++ b/clients/models.py
@@ -312,10 +312,10 @@ INCOME_CHOICES_MONTHLY = [
     'Social Security Income',
     "Veteran's Benefits",
     'Retirement Fund (401), IRA',
+    'Pension Statement',
 ]
 INCOME_CHOICES_YEARLY = [
     'Annuities',
-    'Pension Statement',
     'Checking Account Statement',
     'Savings Account Statement',
     'Mutual Fund Statement',


### PR DESCRIPTION
See #36 for the request.

This will affect 3 clients in production that have pensions as an income type, but they already have mixed yearly/monthly values there, so I will just communicate that those need to be updated to be monthly for consistency. 