### PR TITLE
Pin django-axes to < 2.0, since that had breaking changes

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -8,5 +8,5 @@ django-import-export
 django-localflavor
 requests
 django-solo
-django-axes
+django-axes<2
 pytz


### PR DESCRIPTION
This should fix the travis tests, I think.